### PR TITLE
fix 404 errors for link to releases page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,7 @@ See the [documention](https://p2gx.github.io/phenoboard/) for a tutorial.
 
 ## 📦 Installation
 
-Get started quickly by downloading the latest release for your platform:
-
-- [**Macintosh**](https://p2gx.github.io/phenoboard/releases)  
-- [**Windows**](https://p2gx.github.io/phenoboard/releases)  
-- [**Debian/Ubuntu Linux**](https://p2gx.github.io/phenoboard/releases)  
+Get started quickly by downloading the [latest release](https://github.com/P2GX/phenoboard/releases) for your platform.
 
 > ⚠️ **Warning:** The app is not signed on macOS. Attempting to open it immediately upon download will produce an error. See the [installation instructions](https://p2gx.github.io/phenoboard/help/installation.html#mac) for how to bypass this safely.
 


### PR DESCRIPTION
The different platform links were all going to the same place, and didn't actually go to the list of releases. This points to the github releases page.